### PR TITLE
Add a pure db back end without a cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,7 @@
 
 -------
 
-django-qsessions is a session backend for Django that extends Django's ``cached_db`` session backend
-and ``Session`` model to add following features:
+django-qsessions is a session backend for Django that extends Django's ``Session`` model for along with both the ``cached_db`` and ``db`` backends to add following features:
 
 - Sessions have a foreign key to User
 
@@ -62,9 +61,10 @@ Installation
 Please note that if your system is in production and there are lots of active sessions
 using another session backend, you need to migrate them manually. We have no migration script.
 
-(1) First, make sure you've `configured your cache`_. If you have multiple caches defined in
-    ``CACHES``, Django will use the default cache. To use another cache, set ``SESSION_CACHE_ALIAS``
-    to the name of that cache.
+(1) First, if you're using the cached_db backend, make sure you've
+    `configured your cache`_. If you have multiple caches defined in ``CACHES``, Django
+    will use the default cache. To use another cache, set ``SESSION_CACHE_ALIAS`` to the
+    name of that cache.
 
 (2) Install the latest version from PyPI:
 
@@ -80,7 +80,7 @@ using another session backend, you need to migrate them manually. We have no mig
       ``'django.contrib.sessions.middleware.SessionMiddleware'`` with
       ``'qsessions.middleware.SessionMiddleware'``.
 
-    - Set ``SESSION_ENGINE`` to ``'qsessions.backends.cached_db'``.
+    - Set ``SESSION_ENGINE`` to either ``'qsessions.backends.cached_db'`` or ``'qsessions.backends.db'`` depending on if you want to utilise a cache.
 
 (4) Run migrations to create ``qsessions.models.Session`` model.
 
@@ -98,8 +98,8 @@ For enabling location detection using GeoIP2 (optional):
 
 (6) Set ``GEOIP_PATH`` to a directory for storing GeoIP2 database.
 
-(7) Run the following command to download latest GeoIP2 database. You can add this command to a cron
-    job to update GeoIP2 DB automatically.
+(7) Run the following command to download latest GeoIP2 database. You can add this
+    command to a cron job to update GeoIP2 DB automatically.
 
     .. code-block:: sh
 
@@ -171,7 +171,7 @@ Why not ``django-user-sessions``?
 =================================
 
 `django-user-sessions`_ has the same functionality,
-but it's based on ``db`` backend. Using a cache will improve performance.
+but only implements the ``db`` backend. Using a cache can improve performance.
 
 We got ideas and some codes from django-user-sessions.
 Many thanks to `Bouke Haarsma`_ for writing django-user-sessions.
@@ -181,7 +181,7 @@ Development
 
 * Install development dependencies in your virtualenv with ``pip install -e '.[dev]'``
 * Run tests with coverage using ``py.test --cov .``
-
+* Run tests with the ``db`` backend using ``py.test . --ds tests.db_settings``
 
 TODO
 ====

--- a/qsessions/backends/__init__.py
+++ b/qsessions/backends/__init__.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+from django.conf import settings
+
+def get_session_store_class(*_):
+    engine = import_module(settings.SESSION_ENGINE)
+    return engine.SessionStore

--- a/qsessions/backends/cached_db.py
+++ b/qsessions/backends/cached_db.py
@@ -1,52 +1,11 @@
 from django.contrib.sessions.backends.cached_db import SessionStore as CachedDBStore
-from qsessions import IP_SESSION_KEY, USER_AGENT_SESSION_KEY
-from django.contrib import auth
+from .common import QSessionStoreMixin
 
 KEY_PREFIX = "qsessions.q_cached_db"
 
-
-class SessionStore(CachedDBStore):
+class SessionStore(QSessionStoreMixin, CachedDBStore):
     """
     Implements cached, database backed sessions, with a foreign key to User.
     It also stores IP and User Agent.
     """
     cache_key_prefix = KEY_PREFIX
-
-    def __init__(self, session_key=None, user_agent=None, ip=None):
-        self.modified = False
-        self.user_agent = user_agent[:300] if user_agent else user_agent
-        self.ip = ip
-        super(SessionStore, self).__init__(session_key)
-
-    @classmethod
-    def get_model_class(cls):
-        from qsessions.models import Session
-        return Session
-
-    def load(self):
-        data = super(SessionStore, self).load()
-        if data.get(USER_AGENT_SESSION_KEY) != self.user_agent \
-                or data.get(IP_SESSION_KEY) != self.ip:
-            # If IP or User Agent has changed, set modified to True in order to save
-            # the new IP and User Agent in both Cache and DB
-            self.modified = True
-        return data
-
-    def save(self, must_create=False):
-        # Store IP and User Agent in session_data
-        if USER_AGENT_SESSION_KEY not in self or self[USER_AGENT_SESSION_KEY] != self.user_agent:
-            self[USER_AGENT_SESSION_KEY] = self.user_agent
-        if IP_SESSION_KEY not in self or self[IP_SESSION_KEY] != self.ip:
-            self[IP_SESSION_KEY] = self.ip
-        super(SessionStore, self).save(must_create)
-
-    def create_model_instance(self, data):
-        # Store User, User Agent, and IP in Session (in DB).
-        return self.model(
-            session_key=self._get_or_create_session_key(),
-            session_data=self.encode(data),
-            expire_date=self.get_expiry_date(),
-            user_id=self.get(auth.SESSION_KEY),
-            user_agent=self.user_agent,
-            ip=self.ip
-        )

--- a/qsessions/backends/common.py
+++ b/qsessions/backends/common.py
@@ -1,0 +1,48 @@
+from qsessions import IP_SESSION_KEY, USER_AGENT_SESSION_KEY
+from django.contrib import auth
+
+class QSessionStoreMixin(object):
+    """
+    Implements sessions stored with:
+    - a foreign key to User
+    - IP Adress
+    - User Agent
+    """
+    def __init__(self, session_key=None, user_agent=None, ip=None):
+        self.modified = False
+        self.user_agent = user_agent[:300] if user_agent else user_agent
+        self.ip = ip
+        super(QSessionStoreMixin, self).__init__(session_key)
+
+    @classmethod
+    def get_model_class(cls):
+        from qsessions.models import Session
+        return Session
+
+    def load(self):
+        data = super(QSessionStoreMixin, self).load()
+        if data.get(USER_AGENT_SESSION_KEY) != self.user_agent \
+                or data.get(IP_SESSION_KEY) != self.ip:
+            # If IP or User Agent has changed, set modified to True in order to save
+            # the new IP and User Agent in both Cache and DB
+            self.modified = True
+        return data
+
+    def save(self, must_create=False):
+        # Store IP and User Agent in session_data
+        if USER_AGENT_SESSION_KEY not in self or self[USER_AGENT_SESSION_KEY] != self.user_agent:
+            self[USER_AGENT_SESSION_KEY] = self.user_agent
+        if IP_SESSION_KEY not in self or self[IP_SESSION_KEY] != self.ip:
+            self[IP_SESSION_KEY] = self.ip
+        super(QSessionStoreMixin, self).save(must_create)
+
+    def create_model_instance(self, data):
+        # Store User, User Agent, and IP in Session (in DB).
+        return self.model(
+            session_key=self._get_or_create_session_key(),
+            session_data=self.encode(data),
+            expire_date=self.get_expiry_date(),
+            user_id=self.get(auth.SESSION_KEY),
+            user_agent=self.user_agent,
+            ip=self.ip
+        )

--- a/qsessions/backends/db.py
+++ b/qsessions/backends/db.py
@@ -1,0 +1,9 @@
+from django.contrib.sessions.backends.db import SessionStore as DBStore
+from .common import QSessionStoreMixin
+
+class SessionStore(QSessionStoreMixin, DBStore):
+    """
+    Implements database backed sessions, with a foreign key to User.
+    It also stores IP and User Agent.
+    """
+    pass

--- a/qsessions/models.py
+++ b/qsessions/models.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 import qsessions.geoip as geoip
-from qsessions.backends.cached_db import SessionStore
+from qsessions.backends import get_session_store_class
 
 
 class SessionQuerySet(models.QuerySet):
@@ -14,7 +14,10 @@ class SessionQuerySet(models.QuerySet):
         """
         Delete sessions from both DB and cache (first cache, then DB)
         """
-        caches[settings.SESSION_CACHE_ALIAS].delete_many(SessionStore.cache_key_prefix + s.session_key for s in self)
+        SessionStore = get_session_store_class()
+        prefix = getattr(SessionStore, 'cache_key_prefix', None)
+        if prefix is not None:
+            caches[settings.SESSION_CACHE_ALIAS].delete_many(prefix + s.session_key for s in self)
         return super(SessionQuerySet, self).delete()
 
 
@@ -35,9 +38,7 @@ class Session(AbstractBaseSession):
 
     objects = SessionManager()
 
-    @classmethod
-    def get_session_store_class(cls):
-        return SessionStore
+    get_session_store_class = get_session_store_class
 
     def save(self, *args, **kwargs):
         # FIXME: find a better solution for `created_at` field which does not need an extra query.
@@ -52,7 +53,10 @@ class Session(AbstractBaseSession):
         """
         Delete session from both DB and cache (first cache, then DB)
         """
-        caches[settings.SESSION_CACHE_ALIAS].delete(SessionStore.cache_key_prefix + self.session_key)
+        SessionStore = get_session_store_class()
+        prefix = getattr(SessionStore, 'cache_key_prefix', None)
+        if prefix is not None:
+            caches[settings.SESSION_CACHE_ALIAS].delete(prefix + self.session_key)
         return super(Session, self).delete(*args, **kwargs)
 
     def location(self):

--- a/tests/db_settings.py
+++ b/tests/db_settings.py
@@ -1,0 +1,3 @@
+from .settings import *
+
+SESSION_ENGINE = 'qsessions.backends.db'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,7 +6,8 @@ import pytest
 from django.contrib import auth
 
 from qsessions import IP_SESSION_KEY, USER_AGENT_SESSION_KEY
-from qsessions.backends.cached_db import SessionStore
+from qsessions.backends import get_session_store_class
+SessionStore = get_session_store_class()
 from qsessions.models import Session
 
 

--- a/tests/test_sessionstore.py
+++ b/tests/test_sessionstore.py
@@ -3,10 +3,16 @@ from datetime import timedelta
 import pytest
 from django.contrib import auth
 from django.contrib.sessions.backends.base import CreateError
+from django.conf import settings
 from django.utils.timezone import now
 
-from qsessions.backends.cached_db import SessionStore
 from qsessions.models import Session
+from qsessions.backends import get_session_store_class
+SessionStore = get_session_store_class()
+from qsessions.backends.cached_db import SessionStore as CachedBackend
+from qsessions.backends.db import SessionStore as DBOnlyBackend
+
+import time
 
 
 @pytest.fixture(name='store')
@@ -114,3 +120,12 @@ def test_clear(store):
 
     session = Session.objects.get(pk=store.session_key)
     assert session.user_id is None
+
+
+def test_import():
+    if settings.SESSION_ENGINE.endswith('.cached_db'):
+        assert issubclass(SessionStore, CachedBackend)
+    elif settings.SESSION_ENGINE.endswith('.db'):
+        assert issubclass(SessionStore, DBOnlyBackend)
+    else:
+        assert False, "Unrecognised Session Engine"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36}-dj110,
-    py{27,34,35,36}-dj111,
-    py{34,35,36,37}-dj20,
-    py{35,36,37}-dj21,
-    py{35,36,37}-dj22,
-    py{36,37}-{djmaster}
+    py{27,34,35,36}-{dj110,dj111}-{db,cdb},
+    py{34,35,36,37}-dj20-{db,cdb},
+    py{35,36,37}-{dj21, dj22}-{db,cdb},
+    py{36,37}-{djmaster}-{db,cdb}
 
 [travis]
 unignore_outcomes = True
@@ -21,14 +19,16 @@ DJANGO =
 
 [testenv]
 extras = dev
-commands = py.test {posargs}
+commands=
+    cdb: py.test --ds=tests.settings {posargs}
+    db: py.test --ds=tests.db_settings {posargs}
 usedevelop = True
 deps=
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
-    dj22: Django>=2.2.1,<2.3
+    dj22: Django>=2.2.6,<2.3
     djmaster: https://github.com/django/django/archive/master.tar.gz
 ignore_outcome =
     djmaster: True


### PR DESCRIPTION
To be honest I'm not 100% sure how to fully test this properly.

I've added a new settings module and currently require separate pytest runs to check both.

It may be possible to use fixtures in pytest instead, but then we'd have to avoid evaluating the backend setting at import time.