### PR TITLE
Update download_geoip_db to use new Maxmind download URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,10 +104,13 @@ To enable location detection using GeoIP2 (optional):
 
 (7) Run the following command to download latest GeoIP2 database. You can add this
     command to a cron job to update GeoIP2 DB automatically.
+    Due to `Maxmind license changes`_ you will need to acquire and use a license key for
+    downloading the databases.  You can pass the key on the command line, or in the ``MAXMIND_LICENSE_KEY``
+    environment variable.
 
     .. code-block:: sh
 
-        python manage.py download_geoip_db
+        python manage.py download_geoip_db -k mykey
 
 Usage
 =====
@@ -211,3 +214,4 @@ MIT
 .. _`configured your cache`: https://docs.djangoproject.com/en/dev/topics/cache/
 .. _`django-user-sessions`: https://github.com/Bouke/django-user-sessions
 .. _`Bouke Haarsma`: https://github.com/Bouke
+.. _`Maxmind license changes`: https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/

--- a/qsessions/management/commands/download_geoip_db.py
+++ b/qsessions/management/commands/download_geoip_db.py
@@ -1,15 +1,27 @@
-from django.core.management.base import BaseCommand
-from django.conf import settings
-import urllib.request
-import tarfile
 import os
+import re
+import tarfile
+import urllib.request
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils.http import urlencode
 
 
 class Command(BaseCommand):
-    help = 'Update GeoIP2 database'
+    help = "Update GeoIP2 database"
 
-    def handle(self, verbosity=0, **options):
-        db_path = getattr(settings, 'GEOIP_PATH', None)
+    def add_arguments(self, parser):
+        default_license_key = os.environ.get("MAXMIND_LICENSE_KEY")
+        parser.add_argument(
+            "-k",
+            "--maxmind-license-key",
+            default=default_license_key,
+            required=(not default_license_key),
+        )
+
+    def handle(self, maxmind_license_key, verbosity=0, **options):
+        db_path = getattr(settings, "GEOIP_PATH", None)
         if not db_path:
             if verbosity >= 1:
                 self.stderr.write("No GEOIP_PATH defined, not downloading database.")
@@ -18,21 +30,42 @@ class Command(BaseCommand):
         if not os.path.exists(db_path):
             os.makedirs(db_path)
 
-        for url in [
-            "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz",
-            "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz",
+        for basename, url in [
+            (
+                "GeoLite2-City.tar.gz",
+                self.get_download_url("GeoLite2-City", maxmind_license_key),
+            ),
+            (
+                "GeoLite2-Country.tar.gz",
+                self.get_download_url("GeoLite2-Country", maxmind_license_key),
+            ),
         ]:
-            filename = os.path.join(db_path, os.path.basename(url))
+            filename = os.path.join(db_path, basename)
             if verbosity >= 1:
-                self.stdout.write('Downloading and extracting {url}...'.format(url=url))
+                redacted_url = re.sub("license_key=([^&]+)", "license_key=...", url)
+                self.stdout.write(
+                    "Downloading and extracting {url}...".format(url=redacted_url)
+                )
             urllib.request.urlretrieve(url, filename)
-            self.extract_tar(db_path, filename)
+            self.extract_tar(db_path, filename, verbosity)
             os.remove(filename)
 
     @staticmethod
-    def extract_tar(db_path, tar_path):
+    def get_download_url(edition_id, maxmind_license_key):
+        return "https://download.maxmind.com/app/geoip_download?%s" % urlencode(
+            {
+                "edition_id": edition_id,
+                "license_key": maxmind_license_key,
+                "suffix": "tar.gz",
+            }
+        )
+
+    def extract_tar(self, db_path, tar_path, verbosity):
         with tarfile.open(tar_path) as tarball:
             for tarinfo in tarball:
-                if tarinfo.name.endswith('.mmdb'):
+                if tarinfo.name.endswith(".mmdb"):
                     tarinfo.name = os.path.basename(tarinfo.name)
                     tarball.extract(tarinfo, path=db_path)
+                    if verbosity >= 2:
+                        dest_path = os.path.join(db_path, tarinfo.name)
+                        self.stdout.write("  => %s" % dest_path)


### PR DESCRIPTION
[Maxmind changed their licensing and download URLs](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/) to require a license key.

The old download links no longer work; this adds support for the new scheme in the downloader command.