### PR TITLE
Use gettext_lazy, not ugettext_lazy

### DIFF
--- a/qsessions/admin.py
+++ b/qsessions/admin.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 from django.utils.html import format_html
 from django.utils.timezone import now

--- a/qsessions/models.py
+++ b/qsessions/models.py
@@ -5,7 +5,7 @@ from django.contrib.sessions.base_session import AbstractBaseSession, BaseSessio
 from django.core.cache import caches
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import qsessions.geoip as geoip
 


### PR DESCRIPTION
The `ugettext_lazy` function is marked as deprecated-in-Django-4, so Django 3.1 will warn about it.

In addition, the use of `gettext` instead of `gettext_lazy` in the admin was a little suspect, since it was being used in a class variable context.