### PR TITLE
Django 4.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        django-version: ["3.2", "4.0"]
+        django-version: ["3.2", "4.0", "4.1"]
         exclude:
           - python-version: "3.7"
             django-version: "4.0"
+          - python-version: "3.7"
+            django-version: "4.1"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This depends on https://github.com/django/django/pull/15906 since the default GitHub Actions runners don't have GDAL installed.