### PR TITLE
Replace the "SessionAdmin" class' readonly_fields with has_add_permission and has_change_permission

### DIFF
--- a/qsessions/admin.py
+++ b/qsessions/admin.py
@@ -59,19 +59,6 @@ class OwnerFilter(admin.SimpleListFilter):
 class SessionAdmin(admin.ModelAdmin):
     list_display = ("ip", linkify("user"), "is_valid", "created_at", "expire_date", "device", "location")
     list_select_related = ("user",)
-    readonly_fields = (
-        "ip",
-        "location",
-        "user",
-        "is_valid",
-        "expire_date",
-        "created_at",
-        "updated_at",
-        "user_agent",
-        "device",
-        "session_key",
-        "session_data_decoded",
-    )
     list_filter = ExpiredFilter, OwnerFilter
     fields = (
         "user",
@@ -107,3 +94,9 @@ class SessionAdmin(admin.ModelAdmin):
             '<pre style="white-space: pre-wrap; max-width: 800px; display: inline-block; direction: ltr;">{}</pre>',
             pformat(obj.get_decoded()),
         )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
If you go to the "Add session" form (/admin/qsessions/session/add/), the following exception is thrown due to [line 102 in admin.py](https://github.com/QueraTeam/django-qsessions/blob/v1.1.4/qsessions/admin.py#L102):

```
TypeError: '>' not supported between instances of 'NoneType' and 'datetime.datetime'
```

But even if that bug wasn't present, there would be no point in going to the "Add session" form anyway since all of the fields are read-only.

Similarly, since all of the fields are read-only, the "Change session" form's "SAVE", "Save and add another", and "Save and continue editing" buttons are all kind of confusing since there's nothing to save.

This pull request disables adding and changing, which fixes the exception and makes the interface make more sense.