### PR TITLE
Add official support for Django 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12", "3.11", "3.10"]
-        django-version: ["5.0", "4.2"]
+        django-version: ["5.1", "5.0", "4.2"]
         include:
           - python-version: "3.9"
             django-version: "4.2"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cached_db), and django-qsessions.
 ## Compatibility
 
 - Python: **3.8**, **3.9**, **3.10**, **3.11**, **3.12**
-- Django: **4.2**, **5.0**
+- Django: **4.2**, **5.0**, **5.1**
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Following: https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django