### PR TITLE
Make geoip2 an extra require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- Make `geoip2` an optional dependency. It can be installed using the `geoip2` extra.
+
 # 2.0.0 (Feb 23, 2025)
 
 - Add support for Python 3.13 and drop support for Python 3.8.

--- a/README.md
+++ b/README.md
@@ -115,22 +115,25 @@ migration script.
     python manage.py migrate qsessions
     ```
 
-To enable location detection using GeoIP2 (optional):
+### Use GeoIP2 (optional)
 
-5.  Install `geoip2` package:
+To enable location detection using GeoIP2, you'll need to follow a few extra steps:
+
+1.  Install `django-qsessions` with the `geoip2` extra:
 
     ```sh
-    pip install geoip2
+    pip install "django-qsessions[geoip2]"
     ```
 
-6.  Set `GEOIP_PATH` to a directory for storing GeoIP2 database.
+2.  Set `GEOIP_PATH` to a directory in Django settings for storing GeoIP2
+    database.
 
-7.  Run the following command to download latest GeoIP2 database. You
-    can add this command to a cron job to update GeoIP2 DB
+3.  Run the following command to download the latest GeoIP2 database. You
+    can add this command to a cron job to update the GeoIP2 DB
     automatically. Due to [Maxmind license
-    changes](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)
+    changes](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/),
     you will need to acquire and use a license key for downloading the
-    databases. You can pass the key on the command line, or in the
+    databases. You can pass the key on the command line or in the
     `MAXMIND_LICENSE_KEY` environment variable.
 
     ```sh

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,12 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 dev_requirements = [
     "pre-commit",
-    "geoip2",  # for testing GeoIP2
     "pytest>=7",
     "pytest-cov",
     "pytest-django",
 ]
+
+geoip_requirements = ["geoip2>=4.1.0"]
 
 setup(
     name="django-qsessions",
@@ -29,7 +30,10 @@ setup(
     packages=find_packages(".", include=("qsessions", "qsessions.*")),
     include_package_data=True,
     install_requires=["Django >= 4.2", "ua-parser[regex] >= 1.0.1"],
-    extras_require={"dev": dev_requirements},
+    extras_require={
+        "dev": dev_requirements + geoip_requirements,
+        "geoip2": geoip_requirements,
+    },
     tests_require=dev_requirements,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR improves the installation process for the optional GeoIP2 feature by introducing a package extra.

Previously, while the GeoIP2 integration was optional, users were required to manually `pip install geoip2` separately. This change streamlines the process by defining a `[geoip2]` extra, allowing users to install the library and its optional geo-location dependency in a single command:

```shell
pip install "django-qsessions[geoip2]"
```